### PR TITLE
fix: include measure_count field in User contract

### DIFF
--- a/contracts.js
+++ b/contracts.js
@@ -3,6 +3,7 @@ var userContract = (user) => {
         username: user.get('username'),
         role: user.get('role'),
         id: user.id,
+        measure_count: user.get('measure_count'),
         enabled: user.get('enabled')
     }
 }

--- a/services/userService.js
+++ b/services/userService.js
@@ -31,6 +31,7 @@ var createUser = (username, password) => {
         password: hashedPassword,
         role: 'user',
         salt: salt,
+        measure_count: 0,
         enabled: true
     }).save();
 }


### PR DESCRIPTION
Needed for FETCH_ALL_USERS functionality in tix-web.

(Already implemented locally for tix-web testing and validation.)